### PR TITLE
Fix RiderCard imports

### DIFF
--- a/components/RiderCard.tsx
+++ b/components/RiderCard.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { Card, CardContent } from 'shadcn-ui/card';
-import { Button } from 'shadcn-ui/button';
+import { Card, CardContent } from './ui/card';
+import { Button } from './ui/button';
 import { FC } from 'react';
 
 interface Rider {


### PR DESCRIPTION
## Summary
- fix local `shadcn-ui` imports for RiderCard

## Testing
- `npm test` *(fails: vitest not found)*